### PR TITLE
Added missed signature

### DIFF
--- a/contracts/src/deploy/deployAll.ts
+++ b/contracts/src/deploy/deployAll.ts
@@ -213,7 +213,7 @@ async function deployToken() {
             }
         );
         await tx.prove();
-        let sentTx = await tx.sign([feepayerKey, zkTokenPrivateKey]).send();
+        let sentTx = await tx.sign([feepayerKey, zkTokenPrivateKey, zkTokenAdminPrivateKey]).send();
         if (sentTx.status === 'pending') {
             console.log("hash", sentTx.hash);
         }


### PR DESCRIPTION
The transaction requires signature from `zkTokenAdminPrivateKey`
Otherwise it throws ```{"statusCode":200,"statusText":"Couldn't send zkApp command: (invalid\n \"Invalid_signature: [B62qmZpuEkuf3MeH2WAkxzXRJMBMmZHb1JxSZqqQR8T3jtt2FUTy9wK]\")"}```