### PR TITLE
signature to approve update delegator and protocol can be reused

### DIFF
--- a/contracts/src/pool/Multisig.ts
+++ b/contracts/src/pool/Multisig.ts
@@ -165,12 +165,15 @@ export class UpdateAccountInfo extends Struct({
     oldUser: PublicKey,
     // new account address
     newUser: PublicKey,
+    // signature right to use
+    right: SignatureRight,
     // deadline to use this signature
     deadlineSlot: UInt32
 }) {
     constructor(value: {
         oldUser: PublicKey,
         newUser: PublicKey,
+        right: SignatureRight,
         deadlineSlot: UInt32
     }) {
         super(value);
@@ -183,7 +186,8 @@ export class UpdateAccountInfo extends Struct({
     toFields(): Field[] {
         return this.oldUser.toFields().concat(
             this.newUser.toFields().concat(
-                this.deadlineSlot.toFields()));
+                this.right.toFields().concat(
+                    this.deadlineSlot.toFields())));
     }
 
     hash(): Field {

--- a/contracts/src/pool/PoolFactory.ts
+++ b/contracts/src/pool/PoolFactory.ts
@@ -212,7 +212,8 @@ export class PoolFactory extends TokenContract implements PoolFactoryBase {
         multisig.info.approvedUpgrader.equals(approvedSigner).assertTrue("Incorrect signer list");
         this.network.globalSlotSinceGenesis.requireBetween(UInt32.zero, deadlineSlot);
 
-        const upgradeInfo = new UpdateAccountInfo({ oldUser, newUser, deadlineSlot });
+        const right = SignatureRight.canUpdateProtocol();
+        const upgradeInfo = new UpdateAccountInfo({ oldUser, newUser, right, deadlineSlot });
         multisig.verifyUpdateProtocol(upgradeInfo);
 
         this.protocol.set(newUser);
@@ -231,7 +232,8 @@ export class PoolFactory extends TokenContract implements PoolFactoryBase {
         multisig.info.approvedUpgrader.equals(approvedSigner).assertTrue("Incorrect signer list");
         this.network.globalSlotSinceGenesis.requireBetween(UInt32.zero, deadlineSlot);
 
-        const upgradeInfo = new UpdateAccountInfo({ oldUser, newUser, deadlineSlot });
+        const right = SignatureRight.canUpdateDelegator();
+        const upgradeInfo = new UpdateAccountInfo({ oldUser, newUser, right, deadlineSlot });
         multisig.verifyUpdateDelegator(upgradeInfo);
 
         this.delegator.set(newUser);

--- a/contracts/src/tests/Multisig.test.ts
+++ b/contracts/src/tests/Multisig.test.ts
@@ -330,7 +330,7 @@ describe('Pool data', () => {
         today.setDate(today.getDate() + 1);
         const tomorrow = today.getTime();
         const time = getSlotFromTimestamp(tomorrow);
-        const info = new UpdateAccountInfo({ oldUser: oldAccount!, newUser: newAccount, deadlineSlot: UInt32.from(time) });
+        const info = new UpdateAccountInfo({ oldUser: oldAccount!, newUser: newAccount, right: SignatureRight.canUpdateDelegator(), deadlineSlot: UInt32.from(time) });
 
 
         Provable.log("info validate", info.toFields());
@@ -369,7 +369,7 @@ describe('Pool data', () => {
         today.setDate(today.getDate() + 1);
         const tomorrow = today.getTime();
         const time = getSlotFromTimestamp(tomorrow);
-        const info = new UpdateAccountInfo({ oldUser: oldAccount!, newUser: newAccount, deadlineSlot: UInt32.from(time) });
+        const info = new UpdateAccountInfo({ oldUser: oldAccount!, newUser: newAccount, right: SignatureRight.canUpdateProtocol(), deadlineSlot: UInt32.from(time) });
 
 
         Provable.log("info validate", info.toFields());

--- a/contracts/src/tests/PoolData.test.ts
+++ b/contracts/src/tests/PoolData.test.ts
@@ -215,7 +215,7 @@ describe('Pool data', () => {
     today.setDate(today.getDate() + 1);
     const tomorrow = today.getTime();
     const time = getSlotFromTimestamp(tomorrow);
-    const info = new UpdateAccountInfo({ oldUser, newUser, deadlineSlot: UInt32.from(time) });
+    const info = new UpdateAccountInfo({ oldUser, newUser, right: delegator ? SignatureRight.canUpdateDelegator() : SignatureRight.canUpdateProtocol(), deadlineSlot: UInt32.from(time) });
 
     const signBob = Signature.create(bobKey, info.toFields());
     const signAlice = Signature.create(aliceKey, info.toFields());


### PR DESCRIPTION
The hash of the data that is signed during upgrade operations does not contain information about the action that is being performed, it only contains information regarding the new state that is to be set. This can be seen in the methods which verify a transaction's right to set the protocol or the delegator.



Snippet from Multisig.ts

verifyUpdateDelegator(updateInfo: UpdateAccountInfo) {
    const right = SignatureRight.canUpdateDelegator();
    verifySignature(this.signatures, updateInfo.deadlineSlot, this.info, this.info.approvedUpgrader, updateInfo.toFields(), right);
}

verifyUpdateProtocol(updateInfo: UpdateAccountInfo) {
    const right = SignatureRight.canUpdateProtocol();
    verifySignature(this.signatures, updateInfo.deadlineSlot, this.info, this.info.approvedUpgrader, updateInfo.toFields(), right);
}


As can be seen, both methods utilize the UpdateAccountInfo struct, which contains the oldUser, newUser and deadlineSlot. The UpdateAccountInfo.hash() is what is signed by the signers in order to authorize the upgrades. Due to the hash preimage not containing data regarding the type of action that is being signed, a signature destined for an upgrade of the protocol can be reused for an upgrade of delegator, and vice versa.

Note that since the UpdateAccountInfo contains the oldUser, the signature can only be reused in the instance of protocol and delegator both previously being set to the same value. Additionally, signatures are private inputs into the generated circuits.

Impact

If an attacker is able to obtain the signatures destined for verifyUpdateDelegator() or verifyUpdateProtocol(), he could replay the signature in order to force an unintended update to the protocol or delegator. This also may occur in other fields if other functionality is built using the UpdateAccountInfo.